### PR TITLE
Fix cluster kubeconfig name and added timeout

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,13 +25,13 @@ kubectl wait deployments -n caaph-system caaph-controller-manager --for=conditio
 # create management cluster
 clusterctl generate cluster "${CLUSTER_NAME}" --from template.yaml --config ./clusterctl.yaml > cluster.yaml
 kubectl apply -f cluster.yaml --wait
-kubectl wait cluster "${CLUSTER_NAME}" --for=condition=Ready=true
-clusterctl get kubeconfig "${CLUSTER_NAME}" > ./banshee.kubeconfig
+kubectl wait cluster "${CLUSTER_NAME}" --for=condition=Ready=true --timeout=1h
+clusterctl get kubeconfig "${CLUSTER_NAME}" > ./"${CLUSTER_NAME}".kubeconfig
 kubectl cluster-info --kubeconfig ./"${CLUSTER_NAME}".kubeconfig
 
 # install CAPI to management cluster
-clusterctl init --infrastructure oci --wait-providers --kubeconfig ./"${CLUSTER_NAME}".kubeconfig
-kubectl wait deployments -n caaph-system caaph-controller-manager --for=condition=Available=true --kubeconfig ./"${CLUSTER_NAME}".kubeconfig
+clusterctl init --infrastructure oci --wait-providers --addon helm --kubeconfig ./"${CLUSTER_NAME}".kubeconfig
+kubectl wait deployments -n caaph-system caaph-controller-manager --for=condition=Available=true --kubeconfig ./"${CLUSTER_NAME}".kubeconfig --timeout=1h
 
 # move management cluster resource to management cluster
 clusterctl move --to-kubeconfig ./"${CLUSTER_NAME}".kubeconfig


### PR DESCRIPTION
Hi @alam0rt Hope you are well. Great work on CAPI/OKE automation! I had some minor issues while using the script and they are follows:

- Increased the `timeout` to `1h` since we are using free tier `VM.Standard.A1.Flex` nodes and they are in high demand and had to wait for long time to get the cluster node group created.
- Updated the  `"${CLUSTER_NAME}".kubeconfig` reference.
- Added `--addon helm` in capi init.